### PR TITLE
Breeding Bot - USUM offsets

### DIFF
--- a/PKMN-NTR/Bot/Bot_Breeding7.cs
+++ b/PKMN-NTR/Bot/Bot_Breeding7.cs
@@ -58,6 +58,17 @@ namespace pkmn_ntr.Bot
         public Bot_Breeding7()
         {
             InitializeComponent();
+            if (Program.gCmdWindow.IsUSUM)
+            {
+                // Change target offsets for USUM.
+                eggOff = 0x3307B1E8;
+                dialogOff = 0x6A668C;
+                dialogIn = 0x80008;
+                dialogOut = 0x800080;
+                currentboxOff = 0x33015AA7;
+                // This is stored in the LookupTable already. Redundant variable?
+                eggseedOff = LookupTable.SeedEggOffset;
+            }
         }
 
         private void RunStop_Click(object sender, System.EventArgs e)

--- a/PKMN-NTR/MainForm.cs
+++ b/PKMN-NTR/MainForm.cs
@@ -332,9 +332,9 @@ namespace pkmn_ntr
             }
             if (!(IsUSUM))
             {
-                Delg.SetEnabled(Tools_Breeding, true);
                 Delg.SetEnabled(Tools_SoftReset, true);
             }
+            Delg.SetEnabled(Tools_Breeding, true);
             Delg.SetEnabled(Tool_Trainer, true);
             Delg.SetEnabled(Tool_Items, true);
             Delg.SetEnabled(Tool_Controls, true);


### PR DESCRIPTION
Detect USUM and change offsets accordingly as the Breeding Bot form is initialized.

Ran a box of eggs in UM without issue. I don't have a US save that is far enough through to have the ranch unlocked, but I checked the RAM contents of 0x6A668C with USUMFramework and it appears the same for both games in regards to dialog open/close.

Big thanks to everyone in issue #120 for providing offsets.